### PR TITLE
Add missing gh-pages dependency to cli project

### DIFF
--- a/phaser-fish-single-player-cli-version/package.json
+++ b/phaser-fish-single-player-cli-version/package.json
@@ -14,6 +14,7 @@
     "redux-devtools-extension": "^2.13.8"
   },
   "devDependencies": {
-    "@phaser-cli/scripts": "^2.0.0"
+    "@phaser-cli/scripts": "^2.0.0",
+    "gh-pages": "^2.2.0"
   }
 }


### PR DESCRIPTION
contrary to webpack project, you didn't add the `gh-page` dependency while you use it in the `scripts` section.

ref: https://github.com/EverybodyCodes/Phaser-Fish-Game/blob/ce32f7ccab6aa0aa9f305372291a9de52a9363c8/phaser-fish-single-player-webpack/package.json#L28